### PR TITLE
Fixes to license and readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Node friendly version of [Alex Gorbachev's great SyntaxHighlighter](http://alexg
 
 # Why
 
-Using the [current version of SyntaxHighlighter](https://github.com/alexgorbatchev/SyntaxHighlighter) with nodejs is not straight forward.
+Using the [current version of SyntaxHighlighter](https://github.com/syntaxhighlighter/syntaxhighlighter) with nodejs is not straight forward.
 
 Although it can be installed with npm by using the git repo url as package name, it is not obvious on how to use it with nodejs.
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "licenses": [
     {
       "type": "MIT"
-    },
-    {
-      "type": "LGPL"
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
Assuming the licensing is intended to sync to SyntaxHighlighter's, its out of date from theirs. I've taken the liberty to report this via a pull-request, I hope that's okay.

I also fixed a link in the readme.